### PR TITLE
クエリビルダ機能の追加

### DIFF
--- a/beaker/beaker/common/beaker.py
+++ b/beaker/beaker/common/beaker.py
@@ -4,7 +4,7 @@ from flask import Flask, session as session_by_flask, request as request_by_flas
 from flask_wtf.csrf import CSRFProtect
 from datetime import timedelta
 
-from .db import DbConnecter, Transaction
+from .db import DbConnecter, Transaction, QueryBuilder
 from .csv import CsvCreator
 from .utility import load_yaml
 import logging.config
@@ -376,6 +376,10 @@ class BeakerDB():
     """
     return Transaction(self._connector, self._logger, read_only)
 
+  def get_db_connector(self):
+    return self._connector
+
+
 _beaker_db = BeakerDB(get_config(), logger)
 def start_transaction(read_only = True):
   """トランザクション開始処理
@@ -388,6 +392,11 @@ def start_transaction(read_only = True):
   """
   logger.debug(f'read_only: {read_only}')
   return _beaker_db.start_transaction(read_only=read_only)
+
+def create_query_builder(tx=None):
+  if tx is None:
+    return QueryBuilder(logger, db_conecter=_beaker_db.get_db_connector())
+  return QueryBuilder(logger, tx=tx)
 
 request = request_by_flask
 

--- a/beaker/beaker/common/db.py
+++ b/beaker/beaker/common/db.py
@@ -298,7 +298,7 @@ class QueryBuilder(object):
         tx.save(query, tuple(update_values))
 
   def delete(self):
-    query, query_values = self._query_build("DELETE FROM {self._table_name} ")
+    query, query_values = self._query_build(f"DELETE FROM {self._table_name} ")
     query = self._crean_query(query)
     if self._tx is not None:
       self._tx.save(query, tuple(query_values))

--- a/beaker/beaker/common/db.py
+++ b/beaker/beaker/common/db.py
@@ -1,7 +1,7 @@
 import psycopg2
 from psycopg2.extras import DictCursor
 
-class DbConnecter():
+class DbConnecter(object):
   """DBの接続情報をもつクラス
 
   """
@@ -20,7 +20,7 @@ class DbConnecter():
   def get_connect(self):
     return psycopg2.connect(f"dbname={self.__dbname} host={self.__host} user={self.__user} password={self.__password}")
 
-class Transaction():
+class Transaction(object):
   """ トランザクションを処理を実行するためのクラス
       connector: DBConnecterクラスを使用したDBへの接続情報
       logger: loggingのlogger
@@ -128,7 +128,233 @@ class Transaction():
 
   def __exit__(self, exc_type, exc_value, traceback):
     if exc_type is not None:
-      self.__logger.error(f'エラーの種類: {exc_type}')
-      self.__logger.error(f'エラーの値: {exc_value}')
-      self.__logger.error(traceback)
+      self.__logger.error(f'エラーの種類: {exc_type}\nエラーの値: {exc_value}\n{traceback}')
     self.close(exc_type is None)
+
+from abc import ABC, abstractclassmethod
+from enum import Enum
+
+class FiledType(Enum):
+  AND = "AND"
+  OR = "OR"
+
+class QueryConditon(ABC):
+  """ クエリの条件式"""
+
+  @abstractclassmethod
+  def get_condition(self):
+    pass
+
+class ConditionPart(QueryConditon):
+
+  def __init__(self):
+    self._filed_type = None
+
+  def where(self, filed_name, eval, value):
+    self._fild_name = filed_name
+    self._eval = eval
+    self._value = value
+    self._filed_type= FiledType.AND
+
+  def or_where(self, filed_name, eval, value):
+    self._fild_name = filed_name
+    self._eval = eval
+    self._value = value
+    self._filed_type= FiledType.OR
+
+  def get_condition(self):
+    return f"{self._fild_name} {self._eval} {_define_value_type(self._value)}", self._filed_type, [self._value]
+
+class ConditionGroup(QueryConditon):
+  def __init__(self, condition_type, root_condition=False):
+    self._conditions = []
+    self._values = []
+    self._condition_type = condition_type
+    self._root_condition = root_condition
+
+  def add(self, condition):
+    self._conditions.append(condition)
+  
+  def get_condition(self):
+    
+    if len(self._conditions) == 0:
+      raise Exception("conditionが存在しません")
+    
+    ret_condition = ""
+    for index, condition in enumerate(self._conditions):
+      conditon_str, conditon_type, condition_value = condition.get_condition()
+      if index != 0:
+        ret_condition += f' {conditon_type.value} '
+      ret_condition += f' {conditon_str} '
+      self._values.extend(condition_value)
+    if not self._root_condition and len(self._conditions) > 1:
+      ret_condition = f"({ret_condition}) "
+    return ret_condition, self._condition_type, self._values
+  
+  def exists(self):
+    return len(self._conditions) != 0
+
+import re
+
+class QueryBuilder(object):
+  """ QueryBuilder"""
+
+  def __init__(self, logger, db_conecter=None, tx=None):
+    self._table_name = None
+    self._conditions = ConditionGroup(FiledType.AND, True)
+    self._logger = logger
+    if tx is None and db_conecter is None:
+      raise Exception("トランザクションかDBのコネクタは必須です")
+    elif tx is not None and db_conecter is not None:
+      raise Exception("トランザクションかDBコネクタはどちらかのみを設定してください")
+    self._db_conecter = db_conecter
+    self._tx = tx
+  
+  def table(self, table_name, schema=None):
+    """ テーブル名の指定を行う
+
+    Args:
+        table_name (str): テーブル名
+    """
+    self._table_name = table_name
+    if self._tx is None and schema is not None:
+      raise Exception("スキーマはトランザクションごとに指定してください")
+    self._schema = schema
+    return self
+
+  def where(self, filed_name, eval, value):
+    condition_part = ConditionPart()
+    condition_part.where(filed_name, eval, value)
+    condition_group = ConditionGroup(FiledType.AND)
+    condition_group.add(condition_part)
+    self._conditions.add(condition_group)
+    return self
+
+  def or_where(self, filed_name, eval, value):
+    condition_part = ConditionPart()
+    condition_part.or_where(filed_name, eval, value)
+    condition_group = ConditionGroup(FiledType.OR)
+    condition_group.add(condition_part)
+    self._conditions.add(condition_group)
+    return self
+
+  def select(self, *args):
+    query, query_values = self._query_build(self.__create_select_clause(*args))
+    
+    if self._tx is not None:
+      return self.__find_all(query, query_values, self._tx)
+    else:
+      with Transaction(self._db_conecter, self._logger, True, self._schma) as tx:
+        return self.__find_all(query, query_values, tx)
+
+  def select_one(self, *args):
+    query, query_values = self._query_build(self.__create_select_clause(*args))
+    
+    if self._tx is not None:
+      return self.__find_one(query, query_values, self._tx)
+    else:
+      with Transaction(self._db_conecter, self._logger, True, self._schma) as tx:
+        return self.__find_one(query, query_values, tx)
+
+  def __create_select_clause(self, *args):
+    self._logger.debug(args)
+    select_filed = "*"
+    if len(args) != 0:
+      select_filed = ', '.join(args)
+    return f"SELECT {select_filed} FROM {self._table_name}"
+
+  def __find_all(self, query, query_values, tx):
+    query = self._crean_query(query)
+    if len(query_values) != 0:
+      return tx.find_all(query, tuple(query_values))
+    else:
+      return tx.find_all(query)
+
+  def __find_one(self, query, query_values, tx):
+    query = self._crean_query(query)
+    if len(query_values) != 0:
+      return tx.find_one(query, tuple(query_values))
+    else:
+      return tx.find_one(query)
+
+  def update(self, update_dict):
+    if update_dict is None or not any(update_dict):
+      raise Exception("アップデートのキーが存在しません")
+    before_query = f"UPDATE {self._table_name} SET "
+    update_values = []
+    for index, key in enumerate(update_dict.keys()):
+      if index != 0:
+        before_query += ", "
+      before_query += f"{key} = {_define_value_type(update_dict[key])}"
+      update_values.append(update_dict[key])
+    query, query_values = self._query_build(before_query)
+    update_values.extend(query_values)
+
+    query = self._crean_query(query)
+    if self._tx is not None:
+      self._tx.save(query, tuple(update_values))
+    else:
+      with Transaction(self._db_conecter, self._logger, True, self._schma) as tx:
+        tx.save(query, tuple(update_values))
+
+  def delete(self):
+    query, query_values = self._query_build("DELETE FROM {self._table_name} ")
+    query = self._crean_query(query)
+    if self._tx is not None:
+      self._tx.save(query, tuple(query_values))
+    else:
+      with Transaction(self._db_conecter, self._logger, True, self._schma) as tx:
+        tx.save(query, tuple(query_values))
+
+  def insert(self, insert_dict):
+    if self._table_name is None:
+      raise Exception("テーブルが指定されていません")
+    if insert_dict is None or not any(insert_dict):
+      raise Exception("アップデートのキーが存在しません")
+    insert_values = []
+    key_query = ""
+    value_query = ""
+    for index, key in enumerate(insert_dict.keys()):
+      if index != 0:
+        key_query += ", "
+        value_query += ", "
+      key_query += key
+      value_query += _define_value_type(insert_dict[key])
+      insert_values.append(insert_dict[key])
+    query = f"INSERT INTO {self._table_name} ({key_query}) VALUES ({value_query})"
+    query = self._crean_query(query)
+    if self._tx is not None:
+      self._tx.save(query, tuple(insert_values))
+    else:
+      with Transaction(self._db_conecter, self._logger, True, self._schma) as tx:
+        tx.save(query, tuple(insert_values))
+
+  def _query_build(self, before_query="SELECT * FROM"):
+    if self._table_name is None:
+      raise Exception("テーブルが指定されていません")
+
+    query = f"{before_query}"
+    query_values = []
+    if self._conditions.exists():
+      query_str, _, query_values = self._conditions.get_condition()
+      query += f" WHERE {query_str}"
+    return query, query_values
+  
+  def _crean_query(self, query):
+    query = re.sub('[ 　]+', ' ', query)
+    query = re.sub(' $','', query)
+    query += ';'
+    return query
+
+def _define_value_type(value):
+  """ 値のタイプをもとにDBの値を返却する
+
+  Args:
+      value (any): 値を返却する
+  """
+  if type(value) is str or type(value) is int:
+    return "%s"
+  elif type(value) is dict or type(value) is list:
+    return "%s::json"
+  else:
+    return "%s"

--- a/beaker/beaker/controllers/welcome_controller.py
+++ b/beaker/beaker/controllers/welcome_controller.py
@@ -1,4 +1,4 @@
-from common.beaker import get_session, set_session, render_template, request, logger, create_csv, make_csv_response
+from common.beaker import get_session, set_session, render_template, request, logger, create_csv, make_csv_response, create_query_builder, start_transaction
 
 def welcome():
   welcome_text = "WLECOME BEAKER"
@@ -38,6 +38,23 @@ def welcome_get_csv():
     csv_data = cc.getvalue()
   # test.csvとしてダウンロードさせる
   return make_csv_response(csv_data, 'test')
+
+def welcome_db():
+  # 以下は使用サンプルのため、適宜書き換えてご確認ください
+  # with start_transaction() as tx:
+  #   query_builder = create_query_builder(tx)
+  #   client = query_builder.table('{テーブル名}').where('{フィールド名}', '=', 2).or_where('{フィールド名2}', '=', 3).select()
+  # with start_transaction(False) as tx:
+  #   query_builder = create_query_builder(tx)
+  #   query_builder.table('{テーブル名}').insert({'{フィールド名}': 6, '{フィールド名2}': 'test'})
+  # return render_template('welcome.html', welcome_text = 'DBの取得を行いました')
+  # with start_transaction(False) as tx:
+  #   query_builder = create_query_builder(tx)
+  #   query_builder.table('{テーブル名}').where('{フィールド名}', '=', 6).update({'{フィールド名2}': 'test2'})
+  # with start_transaction(False) as tx:
+  #   query_builder = create_query_builder(tx)
+  #   query_builder.table('{テーブル名}').where('{フィールド名}', '=', 6).delete()
+  return render_template('welcome.html', welcome_text = 'DBに関する確認')
 
 def welcome_error_test():
   raise Exception('エラー発生を確認するテストのためのメソッド!!')

--- a/beaker/beaker/example.config.yml
+++ b/beaker/beaker/example.config.yml
@@ -5,7 +5,7 @@ database:
   host: "localhost"
   dbname: "postgres"
   user: "postgres"
-  password: "postgresk"
+  password: "postgres"
 app:
   port: 5000
   sessionTimeoutMinutes: 30

--- a/beaker/beaker/web.py
+++ b/beaker/beaker/web.py
@@ -1,9 +1,10 @@
 from common.beaker import BeakerRouter
 router = BeakerRouter()
 
-from controllers.welcome_controller import welcome, welcome_post, welcome_get_csv, welcome_error_test
+from controllers.welcome_controller import welcome, welcome_post, welcome_get_csv, welcome_db, welcome_error_test
 
 router.get('/', welcome)
 router.get('/get_csv', welcome_get_csv)
 router.get('/error_test', welcome_error_test)
+router.get('/welcome_db', welcome_db)
 router.post('/welcome_post', welcome_post)


### PR DESCRIPTION
# クエリビルダ機能の拡張
機能の拡張としてクエリビルダを使用できるようにする

# 使用方法
## 取得
下記のコードで該当抽出条件に従ってSQLが生成されます
### 書き方
```
# サンプル
  with start_transaction() as tx:
    query_builder = create_query_builder(tx)
    client = query_builder.table('{テーブル名}').where('{フィールド名}', '=', 2).or_where('{フィールド名2}', '=', 3).select()

# 全項目を取得する必要がない時はselectの引数に与えれば必要分だけの取得になります
client = query_builder.table('{テーブル名}').where('{フィールド名}', '=', 2).or_where('{フィールド名2}', '=', 3).select('{フィールド名3}',{フィールド名4})
```

### 生成されるSQL
`SELECT * FROM {テーブル名} WHERE {フィールド名} = %s OR {フィールド名2} = %s;`
AND条件としたいときはwhereを続けて使用すればAND条件となります

## 登録
登録内容に従ってINSERT文を発行します。
### 書き方
```
  with start_transaction(False) as tx:
    query_builder = create_query_builder(tx)
    query_builder.table('{テーブル名}').insert({'{フィールド名}': 6, '{フィールド名2}': 'test'})

```
### 生成されるSQL文
`INSERT INTO {テーブル名} ({フィールド名}, {フィールド名2}) VALUES (%s, %s);`

## 更新
更新内容に従って更新処理を行います。
## 書き方
```
  with start_transaction(False) as tx:
    query_builder = create_query_builder(tx)
    query_builder.table('{テーブル名}').where('{フィールド名}', '=', 6).update({'{フィールド名2}': 'test2'})

```
### 生成されるSQL文
`UPDATE {テーブル名} SET {フィールド名2} = %s WHERE {フィールド名}= %s;`

## 削除
下記の内容に従って削除処理を行います。
## 書き方
```
  with start_transaction(False) as tx:
    query_builder = create_query_builder(tx)
    query_builder.table('{テーブル名}').where('{フィールド名}', '=', 6).delete()
```
## 生成されるSQL文
`DELETE FROM {テーブル名} WHERE {フィールド名}= %s;`